### PR TITLE
Wqp 746

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "numeral": "~1.5.3",
     "select2-bootstrap-theme": "~0.1.0-beta.4",
     "underscore": "~1.8.3",
-    "handlebars": "~4.0.5"
+    "handlebars": "~4.0.5",
+    "loglevel": "^1.4.0"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
 						<source>bower_components/numeral/min/numeral.min.js</source>
 						<source>bower_components/select2/dist/js/select2.min.js</source>
 						<source>bower_components/handlebars/handlebars.min.js</source>
+						<source>bower_components/loglevel/dist/loglevel.min.js</source>
 						<source>static/vendor/OpenLayers/OpenLayers.js</source>
 						<source>../test/resources/testConfig.js</source>
 					</preloadSources>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 					</sourceIncludes>
 					<sourceExcludes>
 						<include>static/js/angular/**/*.js</include>
-						<include>static/js/onReady.js</include>
+						<include>static/js/portalOnReady.js</include>
 					</sourceExcludes>
 					<specIncludes>
 						<include>vendor/sinon-1.17.2.js</include>

--- a/portal_ui/assets.py
+++ b/portal_ui/assets.py
@@ -27,7 +27,7 @@ bundles = {
         'js/SiteImportWPSUtils.js',
         'js/PortalDataMap.js',
         'js/views/portalViews.js',
-        'js/onReady.js',
+        'js/portalOnReady.js',
         'js/providers.js',
         'js/portalModels.js',
         'js/DataSourceUtils.js',

--- a/portal_ui/static/js/portalModels.js
+++ b/portal_ui/static/js/portalModels.js
@@ -2,7 +2,7 @@
 /*global Config */
 /*global $ */
 /*global _ */
-/*global alert */
+/*global log */
 
 
 var PORTAL = PORTAL || {};
@@ -49,7 +49,7 @@ PORTAL.MODELS.cachedCodes = function (options) {
 			},
 
 			error: function (jqXHR, textStatus, error) {
-				alert('Can\'t  get ' + options.codes + ', Server error: ' + error);
+				log.error('Can\'t  get ' + options.codes + ', Server error: ' + error);
 				fetchDeferred.reject(error);
 			}
 		});
@@ -133,7 +133,7 @@ PORTAL.MODELS.codesWithKeys = function (options) {
 				fetchDeferred.resolve(self.getAll());
 			},
 			error: function (jqXHR, textStatus, error) {
-				alert("Can't get " + options.codes + ', Server error: ' + error);
+				log.error('Can\'t get ' + options.codes + ', Server error: ' + error);
 				fetchDeferred.reject(error);
 			}
 		});
@@ -170,7 +170,7 @@ PORTAL.MODELS.codesWithKeys = function (options) {
 		else {
 			return undefined;
 		}
-	}
+	};
 
 	return self;
 };

--- a/portal_ui/static/js/portalOnReady.js
+++ b/portal_ui/static/js/portalOnReady.js
@@ -37,7 +37,7 @@ $(document).ready(function () {
 	});
 
 	//Initialize subviews
-	downloadFormView.initialize();
+	var initDownloadForm = downloadFormView.initialize();
 	siteMapView.initialize();
 
 	// Add click handler for the Show queries button
@@ -48,6 +48,10 @@ $(document).ready(function () {
 		var resultSection = "<div class=\"show-query-text\"><b>Results</b><br><textarea readonly=\"readonly\" rows='6'>" + PORTAL.queryServices.getFormUrl('Result', queryString) + "</textarea></div>";
 
 		$('#WSFeedback').html(stationSection + resultSection);
+	});
+
+	initDownloadForm.fail(function() {
+		$('#service-error-dialog').modal('show');
 	});
 
 });

--- a/portal_ui/static/js/portalOnReady.js
+++ b/portal_ui/static/js/portalOnReady.js
@@ -5,11 +5,24 @@
 /* global Config */
 /* global IdentifyDialog */
 /* global PortalDataMap */
+/* global log */
 
 var PORTAL = PORTAL || {};
 
 $(document).ready(function () {
 	"use strict";
+	// Set the loglevel
+	if (Config.DEBUG) {
+		log.setLevel('debug', false);
+	}
+	else {
+		log.setLevel('warn', false);
+	}
+
+	log.debug('Debug log message');
+	log.info('Info log message');
+	log.warn('Warn log message');
+	log.error('Error log message');
 
 	var $form = $('#params');
 

--- a/portal_ui/static/js/portalOnReady.js
+++ b/portal_ui/static/js/portalOnReady.js
@@ -11,6 +11,7 @@ var PORTAL = PORTAL || {};
 
 $(document).ready(function () {
 	"use strict";
+
 	// Set the loglevel
 	if (Config.DEBUG) {
 		log.setLevel('debug', false);
@@ -19,13 +20,9 @@ $(document).ready(function () {
 		log.setLevel('warn', false);
 	}
 
-	log.debug('Debug log message');
-	log.info('Info log message');
-	log.warn('Warn log message');
-	log.error('Error log message');
-
 	var $form = $('#params');
 
+	// Create sub views
 	var downloadProgressDialog = PORTAL.VIEWS.downloadProgressDialog($('#download-status-dialog'));
 	var downloadFormView = PORTAL.VIEWS.downloadFormView({
 		$form : $form,
@@ -39,6 +36,7 @@ $(document).ready(function () {
 		downloadFormView : downloadFormView
 	});
 
+	//Initialize subviews
 	downloadFormView.initialize();
 	siteMapView.initialize();
 
@@ -51,7 +49,6 @@ $(document).ready(function () {
 
 		$('#WSFeedback').html(stationSection + resultSection);
 	});
-	// Initialize portal data map and identify dialog
 
 });
 

--- a/portal_ui/static/js/providers.js
+++ b/portal_ui/static/js/providers.js
@@ -2,6 +2,7 @@
 /* global $ */
 /* global _ */
 /* global Config */
+/* global log */
 
 var PORTAL = PORTAL || {};
 PORTAL.MODELS = PORTAL.MODELS || {};
@@ -30,6 +31,7 @@ PORTAL.MODELS.providers = function () {
 				},
 				error: function (jqXHR, textStatus, error) {
 					ids = [];
+					log.error('Unable to retrieve provider list with error: ' + error);
 					deferred.reject(error);
 				}
 			});

--- a/portal_ui/static/js/queryService.js
+++ b/portal_ui/static/js/queryService.js
@@ -1,6 +1,7 @@
 /*jslint browser: true*/
 /* global $ */
 /* global Config */
+/* global log */
 var PORTAL = PORTAL || {};
 
 PORTAL.queryServices = (function () {
@@ -31,6 +32,7 @@ PORTAL.queryServices = (function () {
 				deferred.resolve(jqXHR);
 			},
 			error: function (jqXHR, textStatus) {
+				log.error('Unable to contact the WQP services: ' + textStatus);
 				deferred.resolve('Unable to contact the WQP services: ' + textStatus);
 			}
 		});

--- a/portal_ui/static/js/views/alertView.js
+++ b/portal_ui/static/js/views/alertView.js
@@ -1,3 +1,0 @@
-/**
- * Created by mbucknel on 2/5/16.
- */

--- a/portal_ui/static/js/views/alertView.js
+++ b/portal_ui/static/js/views/alertView.js
@@ -1,0 +1,3 @@
+/**
+ * Created by mbucknel on 2/5/16.
+ */

--- a/portal_ui/static/js/views/biologicalSamplingInputView.js
+++ b/portal_ui/static/js/views/biologicalSamplingInputView.js
@@ -1,4 +1,5 @@
 /* jslint browser: true */
+/* global $ */
 
 var PORTAL = PORTAL || {};
 PORTAL.VIEWS = PORTAL.VIEWS || {};
@@ -18,16 +19,25 @@ PORTAL.VIEWS.biologicalSamplingInputView = function(options) {
 
 	/*
 	 * Initialize select2's and set up any DOM event handlers
+	 * @return Jquery.promise
+	 * 		@resolve - all models have been successfully fetched
+	 * 		@reject - one or models have not been successfully fetched
 	 */
 	self.initialize = function() {
 		var $assemblage = options.$container.find('#assemblage');
 		var $taxonomicName = options.$container.find('#subject-taxonomic-name');
-		options.assemblageModel.fetch().done(function() {
+
+		var fetchAssemblageModel = options.assemblageModel.fetch();
+		var fetchComplete = $.when(fetchAssemblageModel);
+
+		fetchAssemblageModel.done(function() {
 			PORTAL.VIEWS.createCodeSelect($assemblage, {model : options.assemblageModel});
 		});
 		PORTAL.VIEWS.createPagedCodeSelect($taxonomicName, {codes: 'subjecttaxonomicname'},
 			{closeOnSelect : false}
 		);
+
+		return fetchComplete;
 	};
 
 	return self;

--- a/portal_ui/static/js/views/downloadFormView.js
+++ b/portal_ui/static/js/views/downloadFormView.js
@@ -72,7 +72,7 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 		});
 		var siteParameterInputView = PORTAL.VIEWS.siteParameterInputView({
 			$container : options.$form.find('#site-params'),
-			siteTypeModel : PORTAL.MODELS.cachedCodes({codes : 'sitetypee'}),
+			siteTypeModel : PORTAL.MODELS.cachedCodes({codes : 'sitetype'}),
 			organizationModel : PORTAL.MODELS.cachedCodes({codes : 'organization'})
 		});
 		var samplingParametersInputView = PORTAL.VIEWS.samplingParameterInputView({

--- a/portal_ui/static/js/views/downloadFormView.js
+++ b/portal_ui/static/js/views/downloadFormView.js
@@ -72,7 +72,7 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 		});
 		var siteParameterInputView = PORTAL.VIEWS.siteParameterInputView({
 			$container : options.$form.find('#site-params'),
-			siteTypeModel : PORTAL.MODELS.cachedCodes({codes : 'sitetype'}),
+			siteTypeModel : PORTAL.MODELS.cachedCodes({codes : 'sitetypee'}),
 			organizationModel : PORTAL.MODELS.cachedCodes({codes : 'organization'})
 		});
 		var samplingParametersInputView = PORTAL.VIEWS.samplingParameterInputView({

--- a/portal_ui/static/js/views/downloadFormView.js
+++ b/portal_ui/static/js/views/downloadFormView.js
@@ -95,7 +95,7 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 					PORTAL.MODELS.providers.getIds());
 			})
 			.fail(function (error) {
-				alert('Unable to retrieve provider list with error: ' + error);
+				//TODO: add alert handling
 			});
 
 		// Initialize form sub views

--- a/portal_ui/static/js/views/downloadFormView.js
+++ b/portal_ui/static/js/views/downloadFormView.js
@@ -58,6 +58,9 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 
 	/*
 	 * Initializes the form and sets up the DOM event handlers
+	 * @return jquery promise
+	 * 		@resolve - if all initialization including successful fetches are complete
+	 * 		@reject - if any fetches failed.
 	 */
 	self.initialize = function() {
 		var placeInputView = getPlaceInputView();
@@ -89,23 +92,27 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 		});
 
 		// fetch the providers and initialize the providers select
-		PORTAL.MODELS.providers.fetch()
+		var initializeProviders = PORTAL.MODELS.providers.fetch()
 			.done(function () {
 				PORTAL.VIEWS.createStaticSelect2(options.$form.find('#providers-select'),
 					PORTAL.MODELS.providers.getIds());
-			})
-			.fail(function (error) {
-				//TODO: add alert handling
 			});
 
 		// Initialize form sub views
-		placeInputView.initialize();
+		var initPlaceInputView = placeInputView.initialize();
+		var initSiteParameterInputView = siteParameterInputView.initialize();
+		var initSamplingParametersInputView = samplingParametersInputView.initialize();
+		var initBiologicalSamplingInputInputView = biologicalSamplingInputView.initialize();
+		var initComplete = $.when(
+			initBiologicalSamplingInputInputView,
+			initializeProviders,
+			initPlaceInputView,
+			initSamplingParametersInputView,
+			initSiteParameterInputView);
+
+		dataDetailsView.initialize();
 		pointLocationInputView.initialize();
 		boundingBoxInputView.initialize();
-		siteParameterInputView.initialize();
-		samplingParametersInputView.initialize();
-		biologicalSamplingInputView.initialize();
-		dataDetailsView.initialize();
 
 		// Create help popovers which close when you click anywhere else other than another popover trigger.
 		$('html').click(function (e) {
@@ -171,6 +178,8 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 					options.downloadProgressDialog.cancelProgress(message);
 				});
 		});
+
+		return initComplete;
 	};
 
 	/*

--- a/portal_ui/static/js/views/inputValidationView.js
+++ b/portal_ui/static/js/views/inputValidationView.js
@@ -1,3 +1,6 @@
+/* jslint browser: true */
+/* global $ */
+
 var PORTAL = PORTAL || {};
 PORTAL.VIEWS = PORTAL.VIEWS || {};
 //
@@ -8,23 +11,28 @@ PORTAL.VIEWS = PORTAL.VIEWS || {};
 //          contains the errorMessage is the validation did not pass.
 //      updateFnc - optional function takes value and returns the formated value. This function
 //          can assume that isValid has already been called and value is a valid entry.
+//      event - optional. The event that this validation should be triggered on. Defaults to 'change'
 PORTAL.VIEWS.inputValidation = function (spec) {
-    spec.inputEl.change(function () {
-        var inputValue = $(this).val();
-        var result = spec.validationFnc(inputValue);
-        var parent = $(this).parent();
+	"use strict";
 
-        parent.find('.error-message').remove();
-        if (result.isValid) {
-            parent.removeClass('alert alert-danger');
-            if (spec.updateFnc) {
-                $(this).val(spec.updateFnc(inputValue));
-            }
-        }
-        else {
-            parent.addClass('alert alert-danger');
-            parent.append('<div class="error-message">' + result.errorMessage + '</div>');
-        }
-    });
+	var event = spec.event || 'change';
+
+	spec.inputEl.on(event, function (ev) {
+		var inputValue = $(this).val();
+		var result = spec.validationFnc(inputValue, ev);
+		var parent = $(this).parent();
+
+		parent.find('.error-message').remove();
+		if (result.isValid) {
+			parent.removeClass('alert alert-danger');
+			if (spec.updateFnc) {
+				$(this).val(spec.updateFnc(inputValue));
+			}
+		}
+		else {
+			parent.addClass('alert alert-danger');
+			parent.append('<div class="error-message">' + result.errorMessage + '</div>');
+		}
+	});
 };
 

--- a/portal_ui/static/js/views/placeInputView.js
+++ b/portal_ui/static/js/views/placeInputView.js
@@ -203,12 +203,25 @@ PORTAL.VIEWS.placeInputView = function (options) {
 
 			$countySelect.val(_.filter(counties, isInStates)).trigger('change');
 		});
-		$countySelect.on('select2-opening', function (ev) {
-			if (getStateKeys().length === 0) {
-				alert('Please select at least one state');
-
-				ev.preventDefault();
-			}
+		var countyValidation = PORTAL.VIEWS.inputValidation({
+			inputEl : $countySelect,
+			validationFnc : function(val, ev) {
+				var result;
+				if (getStateKeys().length === 0) {
+					ev.preventDefault();
+					result  = {
+						isValid : false,
+						errorMessage : 'Please select at least one state'
+					};
+				}
+				else {
+					result = {
+						isValid : true
+					};
+				}
+				return result;
+			},
+			event : 'select2:opening'
 		});
 	};
 

--- a/portal_ui/static/js/views/placeInputView.js
+++ b/portal_ui/static/js/views/placeInputView.js
@@ -145,6 +145,9 @@ PORTAL.VIEWS.placeInputView = function (options) {
 
 	/*
 	 * Initialize the select2's and add event handlers
+	 * @return Jquery promise
+	 * 		@resolve - When all models have been fetched successfully
+	 * 		@reject - If any of the fetches failed.
 	 */
 	self.initialize = function() {
 		//Initialize select els
@@ -154,6 +157,9 @@ PORTAL.VIEWS.placeInputView = function (options) {
 
 		//Fetch initial model data
 		var fetchCountries = options.countryModel.fetch();
+		var fetchUSStates = options.stateModel.fetch([USA]);
+		var fetchComplete = $.when(fetchCountries, fetchUSStates);
+
 		options.stateModel.fetch([USA]);
 
 		var getCountryKeys = function () {
@@ -203,7 +209,7 @@ PORTAL.VIEWS.placeInputView = function (options) {
 
 			$countySelect.val(_.filter(counties, isInStates)).trigger('change');
 		});
-		var countyValidation = PORTAL.VIEWS.inputValidation({
+		PORTAL.VIEWS.inputValidation({
 			inputEl : $countySelect,
 			validationFnc : function(val, ev) {
 				var result;
@@ -223,6 +229,8 @@ PORTAL.VIEWS.placeInputView = function (options) {
 			},
 			event : 'select2:opening'
 		});
+
+		return fetchComplete;
 	};
 
 	return self;

--- a/portal_ui/static/js/views/pointLocationInputView.js
+++ b/portal_ui/static/js/views/pointLocationInputView.js
@@ -1,5 +1,5 @@
 /* jslint browser: true */
-/* global alert */
+/* global log */
 
 var PORTAL = PORTAL || {};
 PORTAL.VIEWS = PORTAL.VIEWS || {};
@@ -24,7 +24,8 @@ PORTAL.VIEWS.pointLocationInputView = function(options) {
 		};
 
 		var displayError = function(err) {
-			alert ('ERROR(' + err.code + '): ' + err.message);
+			log.error('ERROR(' + err.code + '): ' + err.message);
+			//TODO: Add call to show alert
 		};
 
 		navigator.geolocation.getCurrentPosition(updateInputs, displayError, {

--- a/portal_ui/static/js/views/samplingParameterInputView.js
+++ b/portal_ui/static/js/views/samplingParameterInputView.js
@@ -1,4 +1,5 @@
 /* jslint browser: true */
+/* global $ */
 
 var PORTAL = PORTAL || {};
 PORTAL.VIEWS = PORTAL.VIEWS || {};
@@ -19,6 +20,9 @@ PORTAL.VIEWS.samplingParameterInputView = function(options) {
 
 	/*
 	 * Initializes and sets up the DOM event handlers for the inputs
+	 * @return Jquery.promise
+	 * 		@resolve - all models have been successfully fetched
+	 * 		@reject - one or models have not been successfully fetched
 	 */
 	self.initialize = function() {
 		var $sampleMedia = options.$container.find('#sampleMedia');
@@ -28,10 +32,14 @@ PORTAL.VIEWS.samplingParameterInputView = function(options) {
 		var $startDate = options.$container.find('#startDateLo');
 		var $endDate = options.$container.find('#startDateHi');
 
-		options.sampleMediaModel.fetch().done(function() {
+		var fetchSampleMedia = options.sampleMediaModel.fetch();
+		var fetchCharacteristicType = options.characteristicTypeModel.fetch();
+		var fetchComplete = $.when(fetchSampleMedia, fetchCharacteristicType);
+
+		fetchSampleMedia.done(function() {
 			PORTAL.VIEWS.createCodeSelect($sampleMedia, {model : options.sampleMediaModel});
 		});
-		options.characteristicTypeModel.fetch().done(function() {
+		fetchCharacteristicType.done(function() {
 			PORTAL.VIEWS.createCodeSelect($characteristicType, {model : options.characteristicTypeModel});
 		});
 
@@ -55,6 +63,8 @@ PORTAL.VIEWS.samplingParameterInputView = function(options) {
 				return PORTAL.dateValidator.format(value, false);
 			}
 		});
+
+		return fetchComplete;
 	};
 
 	return self;

--- a/portal_ui/static/js/views/siteParameterInputView.js
+++ b/portal_ui/static/js/views/siteParameterInputView.js
@@ -1,4 +1,5 @@
 /* jslint browser: true */
+/* global $ */
 
 var PORTAL = PORTAL || {};
 PORTAL.VIEWS = PORTAL.VIEWS || {};
@@ -44,17 +45,26 @@ PORTAL.VIEWS.siteParameterInputView = function(options) {
 		});
 	};
 
-	// Initialize the widgets and DOM event handlers
+	/*
+	 * Initialize the widgets and DOM event handlers
+	 * @return Jquery promise
+	 * 		@resolve - when all models have been fetched successfully
+	 * 	    @reject - if any model's fetch failed.
+	 */
 	self.initialize = function() {
 		var $siteTypeSelect = options.$container.find('#siteType');
 		var $organizationSelect = options.$container.find('#organization');
 		var $siteIdInput = options.$container.find('#siteid');
 		var $hucInput = options.$container.find('#huc');
 
-		options.siteTypeModel.fetch().done(function() {
+		var fetchSiteType = options.siteTypeModel.fetch()
+		var fetchOrganization = options.organizationModel.fetch()
+		var fetchComplete = $.when(fetchSiteType, fetchOrganization);
+
+		fetchSiteType.done(function() {
 			PORTAL.VIEWS.createCodeSelect($siteTypeSelect, {model : options.siteTypeModel});
 		});
-		options.organizationModel.fetch().done(function() {
+		fetchOrganization.done(function() {
 			initializeOrganizationSelect($organizationSelect, options.organizationModel);
 		});
 
@@ -68,6 +78,8 @@ PORTAL.VIEWS.siteParameterInputView = function(options) {
 			validationFnc: PORTAL.hucValidator.validate,
 			updateFnc: PORTAL.hucValidator.format
 		});
+
+		return fetchComplete;
 	};
 
 	return self;

--- a/portal_ui/templates/base.html
+++ b/portal_ui/templates/base.html
@@ -26,6 +26,7 @@
 		    Config.CODES_ENDPOINT = "{{ config.CODES_ENDPOINT }}";
 		    Config.SEARCH_QUERY_ENDPOINT = "{{ config.SEARCH_QUERY_ENDPOINT }}";
 		    Config.PUBLIC_SRSNAMES_ENDPOINT = "{{ config.PUBLIC_SRSNAMES_ENDPOINT }}";
+			Config.DEBUG = "{{ config.DEBUG }}" === 'True';
 
 		    Config.QUERY_URLS = {
 		    	Station : Config.SEARCH_QUERY_ENDPOINT + 'Station/search',
@@ -149,7 +150,7 @@
 
 		<script type="text/javascript" src="{{ url_for('bower.static', filename='jquery/dist/jquery.js') }}"></script>
 		<script type="text/javascript" src="{{ url_for('bower.static', filename='bootstrap/dist/js/bootstrap.js') }}"></script>
-
+		<script type="text/javascript" src="{{ url_for('bower.static', filename='loglevel/dist/loglevel.js') }}"></script>
 
 		<script type="text/javascript">
 		    $(document).ready(function() {

--- a/portal_ui/templates/contact_us.html
+++ b/portal_ui/templates/contact_us.html
@@ -29,30 +29,30 @@
                 <table class="form-table">
                   <tr> 
                     <th><label for="name">Name:</label></th>
-                    <td> <input id="name" name="Name" size="30" /></td>
+                    <td> <input id="name" name="Name" size="30" value="{{ request.args.get('name', '') }}" /></td>
                   </tr>
                   <tr> 
                     <th><label for="organization">Organization:</label></th>
                     <td> 
-                      <input id="organization" name="Organization" size="30" />
+                      <input id="organization" name="Organization" size="30" value="{{ request.args.get('organization', '') }}"/>
                     </td>
                   </tr>
                   <tr> 
                     <th><label for="email">Email:</label></th>
                     <td> 
-                      <input id="email" name="Email" size="30" />
+                      <input id="email" name="Email" size="30" value="{{ request.args.get('email', '') }}"/>
                     </td>
                   </tr>
                   <tr> 
                     <th><label for="phone">Phone:</label></th>
                     <td> 
-                      <input id="phone" name="Phone" size="20" />
+                      <input id="phone" name="Phone" size="20" value="{{ request.args.get('phone', '') }}"/>
                     </td>
                   </tr>
                   <tr> 
                     <th><label for="address">Address:</label></th>
                     <td> 
-                      <textarea id="address" name="Physical Address" cols="30" rows="2"></textarea>
+                      <textarea id="address" name="Physical Address" cols="30" rows="2">{{ request.args.get('address', '') }}</textarea>
                       <br/>
                     </td>
                   </tr>
@@ -61,7 +61,7 @@
                   </tr>
                   <tr> 
                     <td colspan="2" align="left"> 
-                      <textarea id="comments" name="Comments" cols="60" rows="6"></textarea>
+                      <textarea id="comments" name="Comments" cols="60" rows="6">{{ request.args.get('comments', '') }}</textarea>
                     </td>
                   </tr>
                   <tr>

--- a/portal_ui/templates/portal.html
+++ b/portal_ui/templates/portal.html
@@ -490,7 +490,8 @@
 					<button type="button" class="close" data-dismiss="modal">&times;</button>
 					<h4>Error</h4>
 				</div>
-				<div class="modal-body">Unable to connect to the Water Quality Portal. To report the issue, please <a href="/contact_us">contact us</a>.</div>
+				<div class="modal-body">Unable to connect to the Water Quality Portal. To report the issue, please
+					<a href="/contact_us/?comments=Unable to initialize the download form.">contact us</a>.</div>
 				<div class="modal-footer">
 					<button id="validate-close-button" type="button" class="btn btn-default" data-dismiss="modal">Ok</button>
 				</div>

--- a/portal_ui/templates/portal.html
+++ b/portal_ui/templates/portal.html
@@ -478,8 +478,21 @@
 				</div>
 				<div class="modal-body"></div>
 				<div class="modal-footer">
-					<button id="validate-close-button" type="button" class="btn btn-default" data-dismiss="modal">Ok
-					</button>
+					<button id="validate-close-button" type="button" class="btn btn-default" data-dismiss="modal">Ok</button>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div id="service-error-dialog" class="modal fade">
+		<div class="modal-dialog modal-sm">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal">&times;</button>
+					<h4>Error</h4>
+				</div>
+				<div class="modal-body">Unable to connect to the Water Quality Portal. To report the issue please <a href="/contact_us.">contact us</a></div>
+				<div class="modal-footer">
+					<button id="validate-close-button" type="button" class="btn btn-default" data-dismiss="modal">Ok</button>
 				</div>
 			</div>
 		</div>

--- a/portal_ui/templates/portal.html
+++ b/portal_ui/templates/portal.html
@@ -490,7 +490,7 @@
 					<button type="button" class="close" data-dismiss="modal">&times;</button>
 					<h4>Error</h4>
 				</div>
-				<div class="modal-body">Unable to connect to the Water Quality Portal. To report the issue please <a href="/contact_us.">contact us</a></div>
+				<div class="modal-body">Unable to connect to the Water Quality Portal. To report the issue, please <a href="/contact_us">contact us</a>.</div>
 				<div class="modal-footer">
 					<button id="validate-close-button" type="button" class="btn btn-default" data-dismiss="modal">Ok</button>
 				</div>

--- a/test/js/unit/portalModelsSpec.js
+++ b/test/js/unit/portalModelsSpec.js
@@ -9,8 +9,7 @@
 /*global sinon */
 /*global jasmine */
 /*global spyOn */
-/*global alert */
-
+/*global log */
 
 describe('Tests for PORTAL.MODELS.cachedCodes', function () {
 	"use strict";
@@ -57,13 +56,13 @@ describe('Tests for PORTAL.MODELS.cachedCodes', function () {
 		expect(failedSpy).not.toHaveBeenCalled();
 	});
 
-	it('Expects unsucessful ajax call to show an alert and to be rejected', function () {
-		spyOn(window, 'alert');
+	it('Expects unsucessful ajax call to show an error message and to be rejected', function () {
+		spyOn(log, 'error');
 		testCodesModel.fetch().done(successSpy).fail(failedSpy);
 
 		server.requests[0].respond(500, 'Bad data');
 
-		expect(alert).toHaveBeenCalled();
+		expect(log.error).toHaveBeenCalled();
 		expect(successSpy).not.toHaveBeenCalled();
 		expect(failedSpy).toHaveBeenCalled();
 	});
@@ -124,11 +123,11 @@ describe('Tests for PORTAL.MODELS.cachedCodesWithKeys', function () {
 		expect(server.requests[0].url).toContain(Config.CODES_ENDPOINT + '/test?parentParm=v1;v2');
 	});
 
-	it('Expects unsuccessful ajax call to show alert window and to reject the promise', function () {
+	it('Expects unsuccessful ajax call to log an error message and to reject the promise', function () {
 		testCodesWithKeysModel.fetch(['v1', 'v2']).done(successSpy).fail(failedSpy);
-		spyOn(window, 'alert');
+		spyOn(log, 'error');
 		server.requests[0].respond(500, 'Bad data');
-		expect(alert).toHaveBeenCalled();
+		expect(log.error).toHaveBeenCalled();
 		expect(successSpy).not.toHaveBeenCalled();
 		expect(failedSpy).toHaveBeenCalled();
 	});

--- a/test/js/unit/providersSpec.js
+++ b/test/js/unit/providersSpec.js
@@ -1,8 +1,9 @@
 /* jslint browser:true */
-/* global describe, beforeEach, afterEach, it, expect, jasmine */
+/* global describe, beforeEach, afterEach, it, expect, jasmine, spyOn */
 /* global sinon */
 /* global Config */
 /* global PORTAL */
+/* global log */
 
 describe('Tests for PORTAL.MODELS.providers', function () {
 	"use strict";
@@ -16,6 +17,7 @@ describe('Tests for PORTAL.MODELS.providers', function () {
 
 		successSpy = jasmine.createSpy('successSpy');
 		failureSpy = jasmine.createSpy('failureSpy');
+		spyOn(log, 'error');
 	});
 
 	afterEach(function () {

--- a/test/js/unit/views/biologicalSamplingInputViewSpec.js
+++ b/test/js/unit/views/biologicalSamplingInputViewSpec.js
@@ -60,4 +60,30 @@ describe('Tests for PORTAL.VIEWS.biologicalSamplingInputView', function() {
 		expect(PORTAL.VIEWS.createCodeSelect).toHaveBeenCalled();
 		expect(PORTAL.VIEWS.createCodeSelect.calls.argsFor(0)[0].attr('id')).toEqual($assemblage.attr('id'));
 	});
+
+	describe('Tests for promise returned from initialize', function() {
+		var initializeSuccessSpy, initializeFailSpy;
+
+		beforeEach(function () {
+			initializeSuccessSpy = jasmine.createSpy('initializeSuccessSpy');
+			initializeFailSpy = jasmine.createSpy('initializeFailSpy');
+
+			testView.initialize().done(initializeSuccessSpy).fail(initializeFailSpy);
+		});
+
+		it('Expects that initialize returned promise is not resolved until assemblage have been successfully fetched', function () {
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+
+			fetchAssemblageDeferred.resolve();
+			expect(initializeSuccessSpy).toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+		});
+
+		it('Expects that initialize returned promise is rejected if assemblage is not successfully fetched', function() {
+			fetchAssemblageDeferred.reject();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).toHaveBeenCalled();
+		});
+	});
 });

--- a/test/js/unit/views/inputValidationViewSpec.js
+++ b/test/js/unit/views/inputValidationViewSpec.js
@@ -67,6 +67,26 @@ describe('Tests for PORTAL.VIEWS.inputValidation', function () {
 		});
 	});
 
+	describe('Tests for PORTAL.VIEWS.inputValidation that specified an event other than change', function() {
+		beforeEach(function () {
+			PORTAL.VIEWS.inputValidation({
+				inputEl: $('input[type="text"]'),
+				validationFnc: validationFnc,
+				event: 'dummy-event'
+			});
+		});
+
+		it('Expects a failed validation to show the error message when the dummy-event is triggered, not when change is triggered', function() {
+			$('#test-input1').val('Val2').change();
+			expect($('#input-parent1').attr('class')).not.toContain('alert alert-danger');
+			expect($('#input-parent1').find('.error-message').length).toBe(0);
+
+			$('#test-input1').trigger('dummy-event');
+			expect($('#input-parent1').attr('class')).toEqual('alert alert-danger');
+			expect($('#input-parent1').find('.error-message').html()).toEqual('Value must be Val1');
+		});
+	});
+
 	describe('Tests for PORTAL.VIEWS.inputValidation with an updateFnc', function () {
 		var fnc;
 

--- a/test/js/unit/views/placeInputViewSpec.js
+++ b/test/js/unit/views/placeInputViewSpec.js
@@ -3,7 +3,6 @@
 /*global $ */
 /*global PORTAL */
 /*global Config */
-/*global alert */
 
 describe('Test PORTAL.VIEWS.placeInputView', function () {
 	"use strict";
@@ -147,9 +146,8 @@ describe('Test PORTAL.VIEWS.placeInputView', function () {
 		expect($countySelect.val()).toEqual(['US:02:01']);
 	});
 
-	it('Expects that the alert will be shown if a user tries to open the county select if no states are selected', function() {
-		spyOn(window, 'alert');
-		$countySelect.trigger('select2-opening');
-		expect(window.alert).toHaveBeenCalled();
+	it('Expects that an error will be shown if a user tries to open the county select if no states are selected', function() {
+		$countySelect.trigger('select2:opening');
+		expect($countySelect.parent().find('.error-message').length).toBe(1);
 	});
 });

--- a/test/js/unit/views/samplingParameterInputViewSpec.js
+++ b/test/js/unit/views/samplingParameterInputViewSpec.js
@@ -80,6 +80,44 @@ describe('Tests for PORTAL.VIEWS.samplingParameterInputView', function() {
 		expect(PORTAL.VIEWS.createCodeSelect.calls.argsFor(1)[0].attr('id')).toEqual($characteristicType.attr('id'));
 	});
 
+	describe('Tests for promise returned from initialize', function() {
+		var initializeSuccessSpy, initializeFailSpy;
+
+		beforeEach(function () {
+			initializeSuccessSpy = jasmine.createSpy('initializeSuccessSpy');
+			initializeFailSpy = jasmine.createSpy('initializeFailSpy');
+
+			testView.initialize().done(initializeSuccessSpy).fail(initializeFailSpy);
+		});
+
+		it('Expects that initialize returned promise is not resolved until both the sample media and characteristic type have been successfully fetched', function () {
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+
+			fetchSampleMediaDeferred.resolve();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+
+			fetchCharacteristicTypeDeferred.resolve();
+			expect(initializeSuccessSpy).toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+		});
+
+		it('Expects that initialize returned promise is rejected if sample media is fetched but characteristic types are not successfully fetched', function() {
+			fetchSampleMediaDeferred.resolve();
+			fetchCharacteristicTypeDeferred.reject();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).toHaveBeenCalled();
+		});
+
+		it('Expects that initialize returned promise is rejected if characteristic type is fetched but sample media are not successfully fetched', function() {
+			fetchSampleMediaDeferred.reject();
+			fetchCharacteristicTypeDeferred.reject();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).toHaveBeenCalled();
+		});
+	});
+
 	it('Expects that date fields only allow dates as input, otherwise they are tagged with an error message', function() {
 		testView.initialize();
 		$startDate.val('AAA').trigger('change');

--- a/test/js/unit/views/siteParameterInputViewSpec.js
+++ b/test/js/unit/views/siteParameterInputViewSpec.js
@@ -73,6 +73,44 @@ describe('Tests for PORTAL.VIEWS.siteParameterInputView', function() {
 		expect(PORTAL.VIEWS.createCodeSelect.calls.argsFor(1)[0].attr('id')).toEqual($organization.attr('id'));
 	});
 
+	describe('Tests for promise returned from initialize', function() {
+		var initializeSuccessSpy, initializeFailSpy;
+
+		beforeEach(function () {
+			initializeSuccessSpy = jasmine.createSpy('initializeSuccessSpy');
+			initializeFailSpy = jasmine.createSpy('initializeFailSpy');
+
+			testView.initialize().done(initializeSuccessSpy).fail(initializeFailSpy);
+		});
+
+		it('Expects that initialize returned promise is not resolved until both the siteType and organizations have been successfully fetched', function () {
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+
+			fetchSiteTypeDeferred.resolve();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+
+			fetchOrgDeferred.resolve();
+			expect(initializeSuccessSpy).toHaveBeenCalled();
+			expect(initializeFailSpy).not.toHaveBeenCalled();
+		});
+
+		it('Expects that initialize returned promise is rejected if siteType is fetched but organizations are not successfully fetched', function() {
+			fetchSiteTypeDeferred.resolve();
+			fetchOrgDeferred.reject();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).toHaveBeenCalled();
+		});
+
+		it('Expects that initialize returned promise is rejected if organization is fetched but siteTypes are not successfully fetched', function() {
+			fetchSiteTypeDeferred.reject();
+			fetchOrgDeferred.reject();
+			expect(initializeSuccessSpy).not.toHaveBeenCalled();
+			expect(initializeFailSpy).toHaveBeenCalled();
+		});
+	});
+
 	it('Expects that invalid site ids are flagged with an error message', function() {
 		testView.initialize();
 		$siteId.val('abc').trigger('change');


### PR DESCRIPTION
Added a javascript logging library. Use this rather then console.log and/or alerts.

When initializing the form, the code uses promises to detect when all lookups have been successfully fetched. If any fail, an error modal will be shown. It asks the user to report the error via a link to the contact form. The contact form comment field is filled out with a description of the error.