### PR TITLE
Wqp 490

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node/node node_modules/karma/bin/karma start test/js/karma.conf.js --single-run --browsers Firefox --reporters dots,coverage"
+    "test": "node_modules/karma/bin/karma start test/js/karma.conf.js --no-single-run --browsers \"\" --reporters progress"
   },
   "repository": {
     "type": "git",

--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,11 @@
 					<execution>
 						<id>javascript tests</id>
 						<goals>
-							<goal>npm</goal>
+							<goal>karma</goal>
 						</goals>
 						<phase>test</phase>
 						<configuration>
-							<arguments>test</arguments>
+							<karmaConfPath>test/js/karma.conf.js</karmaConfPath>
 						</configuration>
 					</execution>
 				</executions>

--- a/portal_ui/assets.py
+++ b/portal_ui/assets.py
@@ -40,6 +40,7 @@ bundles = {
         'js/views/samplingParameterInputView.js',
         'js/views/biologicalSamplingInputView.js',
         'js/views/dataDetailsView.js',
+        'js/views/showAPIView.js',
         'js/portalHelp.js',
         'js/stateFIPS.js',
         'js/dateValidator.js',

--- a/portal_ui/static/js/map/siteLayer.js
+++ b/portal_ui/static/js/map/siteLayer.js
@@ -15,6 +15,7 @@ PORTAL.MAP.siteLayer = (function() {
 	var self = {};
 
 	var WQP_SITE_LAYER_NAME = 'wqp_sites';
+	var WFS_VERSION = '1.1.0';
 
 	var getSearchParams = function (queryParamArray) {
 		var queryString = PORTAL.UTILS.getQueryString(queryParamArray, ['mimeType', 'zip'], true);
@@ -103,6 +104,18 @@ PORTAL.MAP.siteLayer = (function() {
 		});
 	};
 
+	self.getWfsGetFeatureUrl = function(queryParamArray) {
+		var queryData = {
+			request : 'GetFeature',
+			service : 'wfs',
+			version : WFS_VERSION,
+			typeName : WQP_SITE_LAYER_NAME,
+			searchParams : getSearchParams(queryParamArray),
+			outputFormat : 'application/json'
+		};
+		return Config.SITES_GEOSERVER_ENDPOINT + 'wfs/?' + $.param(queryData);
+	};
+
 	/*
 	 * @param {Array of Object with name and value properties} queryParamArray - query parameters to be used to retrieve the sites
 	 * @param {ol.Extent} boundingBox - limit the request to look for features in this boundingBox
@@ -122,8 +135,6 @@ PORTAL.MAP.siteLayer = (function() {
 			featureNS: '',
 			featurePrefix : '',
 			featureTypes : [WQP_SITE_LAYER_NAME],
-			outputFormat : 'application/json',
-			maxFeatures : 20,
 			srsName : 'EPSG:900913',
 			geometryName : 'the_geom',
 			bbox :	boundingBox
@@ -138,7 +149,7 @@ PORTAL.MAP.siteLayer = (function() {
 			'</PropertyIsEqualTo>' + $filter.html() + '</And>'
 		);
 		getFeatureDoc = '<GetFeature xmlns="http://www.opengis.net/wfs" ' +
-			'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" service="WFS" version="1.1.0" ' +
+			'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" service="WFS" version="' + WFS_VERSION + '" ' +
 			'xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">' +
 			$(getFeatureQueryDoc).html() +
 			'</GetFeature>';

--- a/portal_ui/static/js/portalOnReady.js
+++ b/portal_ui/static/js/portalOnReady.js
@@ -33,20 +33,15 @@ $(document).ready(function () {
 		downloadProgressDialog : downloadProgressDialog,
 		downloadFormView : downloadFormView
 	});
+	var showAPIView = PORTAL.VIEWS.showAPIView({
+		$container : $('#show-queries-div'),
+		getQueryParamArray : downloadFormView.getQueryParamArray
+	});
 
 	//Initialize subviews
 	var initDownloadForm = downloadFormView.initialize();
 	siteMapView.initialize();
-
-	// Add click handler for the Show queries button
-	$('#show-queries-button').click(function () {
-		// Generate the request from the form
-		var queryString = PORTAL.UTILS.getQueryString(downloadFormView.getQueryParamArray());
-		var stationSection = "<div class=\"show-query-text\"><b>Sites</b><br><textarea readonly=\"readonly\" rows='6'>" + PORTAL.queryServices.getFormUrl('Station', queryString) + "</textarea></div>";
-		var resultSection = "<div class=\"show-query-text\"><b>Results</b><br><textarea readonly=\"readonly\" rows='6'>" + PORTAL.queryServices.getFormUrl('Result', queryString) + "</textarea></div>";
-
-		$('#WSFeedback').html(stationSection + resultSection);
-	});
+	showAPIView.initialize();
 
 	initDownloadForm.fail(function() {
 		$('#service-error-dialog').modal('show');

--- a/portal_ui/static/js/views/showAPIView.js
+++ b/portal_ui/static/js/views/showAPIView.js
@@ -20,15 +20,18 @@ PORTAL.VIEWS.showAPIView = function(options) {
 		var $apiQueryDiv = options.$container.find('#api-queries-div');
 		var $sitesText = options.$container.find('#sites-query-div textarea');
 		var $resultsText = options.$container.find('#results-query-div textarea');
+		var $wfsText = options.$container.find('#getfeature-query-div textarea');
 
 		options.$container.find('#show-queries-button').click(function() {
-			var queryString = PORTAL.UTILS.getQueryString(options.getQueryParamArray());
+			var queryParamArray = options.getQueryParamArray();
+			var queryString = PORTAL.UTILS.getQueryString(queryParamArray);
 
 			$apiQueryDiv.show();
 			$sitesText.html(PORTAL.queryServices.getFormUrl('Station', queryString));
 			$resultsText.html(PORTAL.queryServices.getFormUrl('Result', queryString));
+			$wfsText.html(PORTAL.MAP.siteLayer.getWfsGetFeatureUrl(queryParamArray));
 		});
-	}
+	};
 
 	return self;
 

--- a/portal_ui/static/js/views/showAPIView.js
+++ b/portal_ui/static/js/views/showAPIView.js
@@ -1,0 +1,36 @@
+/* jslint browser: true */
+
+var PORTAL = PORTAL || {};
+
+PORTAL.VIEWS = PORTAL.VIEWS || {};
+
+/*
+ * Initializes the windows which show the various API calls
+ * @param {Object} options
+ * 		@prop {Jquery element} $container - The container containing the show button and the query windows.
+ * 		@prop {Function} getQueryParamArray - Returns the current query parameter array
+ 	* 		@returns {Array of Objects with name and value properties}
+ */
+PORTAL.VIEWS.showAPIView = function(options) {
+	"use strict";
+
+	var self = {};
+
+	self.initialize = function() {
+		var $apiQueryDiv = options.$container.find('#api-queries-div');
+		var $sitesText = options.$container.find('#sites-query-div textarea');
+		var $resultsText = options.$container.find('#results-query-div textarea');
+
+		options.$container.find('#show-queries-button').click(function() {
+			var queryString = PORTAL.UTILS.getQueryString(options.getQueryParamArray());
+
+			$apiQueryDiv.show();
+			$sitesText.html(PORTAL.queryServices.getFormUrl('Station', queryString));
+			$resultsText.html(PORTAL.queryServices.getFormUrl('Result', queryString));
+		});
+	}
+
+	return self;
+
+};
+

--- a/portal_ui/static/less/portal_form.less
+++ b/portal_ui/static/less/portal_form.less
@@ -376,11 +376,15 @@
 
 #show-queries-div {
   background-color: @secondary-panel-color;
-  .show-query-text {
-    margin-top: 10px;
-  }
-  textarea {
-    width: 100%;
+  #api-queries-div {
+    display: none;
+    .show-query-text {
+      margin-top: 10px;
+
+      textarea {
+        width: 100%;
+      }
+    }
   }
 }
 

--- a/portal_ui/templates/portal.html
+++ b/portal_ui/templates/portal.html
@@ -413,7 +413,18 @@
 					<button class="btn" id="show-queries-button" type="button">Show RESTlike queries</button>
 					&nbsp;
 					<button type="button" id="WQXSchemaHelp" class="popover-help" data-help="xmlSchema">?</button>
-					<div id="WSFeedback"></div>
+					<div id="api-queries-div">
+						<div class="show-query-text" id="sites-query-div">
+							<b>Sites</b>
+							<br/>
+							<textarea readonly="readonly" rows="6"></textarea>
+						</div>
+						<div class="show-query-text" id="results-query-div">
+							<b>Results</b>
+							<br/>
+							<textarea readonly="readonly" rows="6"></textarea>
+						</div>
+					</div>
 				</div>
 			</div>
 		</form>

--- a/portal_ui/templates/portal.html
+++ b/portal_ui/templates/portal.html
@@ -410,7 +410,7 @@
 					</div>
 				</div>
 				<div id="show-queries-div" class="panel-body">
-					<button class="btn" id="show-queries-button" type="button">Show RESTlike queries</button>
+					<button class="btn" id="show-queries-button" type="button">Show API queries</button>
 					&nbsp;
 					<button type="button" id="WQXSchemaHelp" class="popover-help" data-help="xmlSchema">?</button>
 					<div id="api-queries-div">
@@ -421,6 +421,11 @@
 						</div>
 						<div class="show-query-text" id="results-query-div">
 							<b>Results</b>
+							<br/>
+							<textarea readonly="readonly" rows="6"></textarea>
+						</div>
+						<div class="show-query-text" id="getfeature-query-div">
+							<b>WFS GetFeature</b>
 							<br/>
 							<textarea readonly="readonly" rows="6"></textarea>
 						</div>

--- a/test/js/karma.conf.js
+++ b/test/js/karma.conf.js
@@ -51,7 +51,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['dots', 'coverage'],
 
     coverageReporter: {
       reporters : [
@@ -79,12 +79,12 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: [],
+    browsers: ['Firefox'],
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+    singleRun: true,
 
     // Concurrency level
     // how many browser should be started simultaneous

--- a/test/js/unit/map/siteLayerSpec.js
+++ b/test/js/unit/map/siteLayerSpec.js
@@ -89,6 +89,15 @@ describe('PORTAL.MAP.siteLayer tests', function() {
 		});
 	});
 
+	describe('Tests for getWfsGetFeatureUrl', function() {
+		var queryParamArray = [{name: 'statecode', value: 'US:55'}, {name: 'countycode', value: 'US:55:025'}];
+
+		it('Expects the queryParamArray to be formatted into a semicolon separated value', function() {
+			var urlString = PORTAL.MAP.siteLayer.getWfsGetFeatureUrl(queryParamArray);
+			expect(urlString).toContain('searchParams=' + encodeURIComponent('statecode:US:55;countycode:US:55:025'));
+		});
+	});
+
 	describe('Tests for getWQPSitesFeature', function() {
 		var queryParamArray = [{name: 'statecode', value: 'US:55'}, {name: 'countycode', value: 'US:55:025'}];
 		var boundingBox = [-9955464,  5315278, -9949960, 5319405];

--- a/test/js/unit/views/showAPIViewSpec.js
+++ b/test/js/unit/views/showAPIViewSpec.js
@@ -1,0 +1,46 @@
+/* jslint browser: true */
+/* global describe, beforeEach, afterEach, it, expect, jasmine */
+/* global $ */
+/* global PORTAL */
+
+describe('Tests for PORTAL.VIEWS.showAPIViewSpec', function() {
+	"use strict";
+
+	var $testDiv;
+	var testView;
+	var mockGetQueryParamArray;
+
+	beforeEach(function() {
+		$('body').append('<div id="test-div">' +
+			'<button type="button"  id="show-queries-button"></button>' +
+				'<div id="sites-query-div"><textarea></textarea></div>' +
+				'<div id="results-query-div"><textarea></textarea></div>' +
+				'<div id="getfeature-query-div"><textarea></textarea></div>' +
+				'</div>'
+		);
+		$testDiv = $('#test-div');
+
+		mockGetQueryParamArray = jasmine.createSpy('mockGetQueryParamArray').and.returnValue([
+			{name : 'Testparam1', value : 'value1'},
+			{name : 'Testparam2', value : 'value2'}
+		]);
+
+		testView = PORTAL.VIEWS.showAPIView({
+			$container : $testDiv,
+			getQueryParamArray : mockGetQueryParamArray
+		});
+		testView.initialize();
+	});
+
+	afterEach(function() {
+		$testDiv.remove();
+	});
+
+	it('Expects that clicking on the show-queries-button fills in the text areas appropriately', function() {
+		$('#show-queries-button').trigger('click');
+		expect($('#sites-query-div textarea').html()).toContain('Station?Testparam1=value1&amp;Testparam2=value2');
+		expect($('#results-query-div textarea').html()).toContain('Result?Testparam1=value1&amp;Testparam2=value2');
+		expect($('#getfeature-query-div textarea').html()).toContain('searchParams=' + encodeURIComponent('Testparam1:value1;Testparam2:value2'));
+	});
+});
+


### PR DESCRIPTION
Moved the code which handles the Show API queries to its own views. Put the markup all in portal.html instead of creating it on the fly. The click handler now retrieves the current query parameters,formats the three API queries, puts the query strings in the mark up and shows the area.