### PR TITLE
add an announcement banner for shutdown

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,3 +43,6 @@ PROVIDER_PAGES = False
 
 # set the local base url, this deals with the weird way we do wsgi around here
 LOCAL_BASE_URL = ''
+
+#Allow for setting an announcement banner without having to release code
+ANNOUNCEMENT_BANNER = None

--- a/portal_ui/templates/base.html
+++ b/portal_ui/templates/base.html
@@ -134,7 +134,12 @@
 				    </div>          
 				</nav>				
 			{% endblock %}
-			
+			{% if config.ANNOUNCEMENT_BANNER %}
+            <div id="announcement"></div>
+            <script>
+                document.getElementById("announcement").innerHTML = '{{ config.ANNOUNCEMENT_BANNER|safe }}';
+            </script>
+            {% endif %}
 			{% block page_content %}{% endblock %}
 			
 			<div id="footer-content">


### PR DESCRIPTION
this will allow for quickly changing an announcement.  javascript should mean that (hopefully) there isn't stuff ingested into google for weeks