### PR TITLE
Wqp 833

### DIFF
--- a/portal_ui/static/js/views/downloadFormView.js
+++ b/portal_ui/static/js/views/downloadFormView.js
@@ -79,7 +79,7 @@ PORTAL.VIEWS.downloadFormView = function(options) {
 		var nldiView = PORTAL.VIEWS.nldiView({
 			insetMapDivId : 'nldi-inset-map',
 			mapDivId : 'nldi-map',
-			$siteInputContainer : options.$form.find('#nldi-sites-container')
+			$inputContainer : options.$form.find('#nldi-param-container')
 		});
 		var samplingParametersInputView = PORTAL.VIEWS.samplingParameterInputView({
 			$container : options.$form.find('#sampling'),

--- a/portal_ui/static/js/views/nldiView.js
+++ b/portal_ui/static/js/views/nldiView.js
@@ -100,11 +100,18 @@ PORTAL.VIEWS.nldiView  = function(options) {
 	 * @param {String} comId
 	 * @param {String} navigate
 	 * @param {String}  distance
-	 * @returns {String{
+	 * @returns {String}
 	 */
 	var getNldiUrl = function(comid, navigate, distance) {
 		return Config.NLDI_SERVICES_ENDPOINT + 'comid/' + comid + '/navigate/' + navigate + '/wqp?distance=' + distance;
 	};
+
+	/*
+	 * @param {String} comId
+	 * @param {String} navigate
+	 * @param {String}  distance
+	 * @returns {jqXHR}
+	 */
 	var fetchNldiSites = function(comid, navigate, distance) {
 		return $.ajax({
 			url : getNldiUrl(comid, navigate, distance),

--- a/portal_ui/templates/portal.html
+++ b/portal_ui/templates/portal.html
@@ -191,7 +191,7 @@
 							<label for="nldi-picker">Search Upstream and Downstream</label>
 							<button type="button" class="help-link popover-help" id="nldiHelp" data-help="nldi">?</button>
 						</div>
-						<div id="nldi-sites-container"></div>
+						<div id="nldi-param-container"></div>
 						<div id="nldi-inset-map"></div>
 					</div>
 				</div>


### PR DESCRIPTION
Rather than putting all of the sites returned from the NLDI service call into the query form, use the new nldiurl parameter. Allows removal of the limit of 50 sites.