### PR TITLE
If a count source is missing return the string '0' rather than the in…

### DIFF
--- a/test/js/portal_ui/queryServiceSpec.js
+++ b/test/js/portal_ui/queryServiceSpec.js
@@ -60,7 +60,7 @@ describe('Tests for queryService', function() {
 			expect(successSpy.calls.argsFor(0)).toEqual([{
 				total : {sites : '492', results : '6,641', activities :'664'},
 				NWIS : {sites : '492', results : '6,641', activities : '664'},
-				STORET : {sites : 0, results : 0, activities : 0}
+				STORET : {sites : '0', results : '0', activities : '0'}
 			}]);
 		});
 

--- a/wqp/portal_ui/static/js/queryService.js
+++ b/wqp/portal_ui/static/js/queryService.js
@@ -31,7 +31,7 @@ PORTAL.queryServices = (function () {
 		var formatCount = function(countData, key) {
 			var countString = _.has(countData, key) ? countData[key] : '0';
 			var result = numeral(countString).format('0,0');
-			return (result === '0') ? 0 : result;
+			return (result === '0') ? '0' : result;
 		};
 
 		$.ajax({


### PR DESCRIPTION
…teger 0.